### PR TITLE
revamped bitreader; with new functionality and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,72 @@
-# BitReader [![Go Report Card](https://goreportcard.com/badge/github.com/pektezol/bitreader)](https://goreportcard.com/report/github.com/pektezol/bitreader) [![License: LGPL 2.1](https://img.shields.io/badge/License-LGPL_v2.1-blue.svg)](https://github.com/pektezol/bitreader/blob/main/LICENSE) [![Go Reference](https://pkg.go.dev/badge/github.com/pektezol/bitreader.svg)](https://pkg.go.dev/github.com/pektezol/bitreader)
-A simple bit reader with big/little-endian support for golang.\
-Reads stream data from an io.Reader; can read from os.File and a byte array with bytes.NewReader(array).\
-Uses bitwise operations.\
-Support reading up to 64 bits at one time.\
-Includes wrapper functions for most used data types.\
-Error checking on all but wrapper functions.
+# BitReader [![Go Reference](https://pkg.go.dev/badge/github.com/pektezol/bitreader.svg)](https://pkg.go.dev/github.com/pektezol/bitreader) [![Go Report Card](https://goreportcard.com/badge/github.com/pektezol/bitreader)](https://goreportcard.com/report/github.com/pektezol/bitreader) [![License: LGPL 2.1](https://img.shields.io/badge/License-LGPL_v2.1-blue.svg)](https://github.com/pektezol/bitreader/blob/main/LICENSE) 
+A simple bit reader with big/little-endian support for golang.
 
 ## Installation
 ```bash
 $ go get github.com/pektezol/bitreader
 ```
 
-## Usage
+## Usage Examples
 
 ```go
 import "github.com/pektezol/bitreader"
 
-// data:  io.Reader  Data to read from an io stream
-// le:    bool       Little-endian(true) or big-endian(false) state
-reader := bitreader.Reader(data, le)
+// ioStream:        io.Reader  Data to read from an io stream
+// byteStream:      []byte     Data to read from a byte slice
+// littleEndian:    bool       Little-endian(true) or big-endian(false) state
+reader := bitreader.NewReader(ioStream, le)
+reader := bitreader.NewReaderFromBytes(byteStream, le)
+
+// Fork Reader, Copies Current Reader
+newReader, err := reader.Fork()
+
+// Read Total Number of Bits Left
+bits, err := reader.ReadRemainingBits()
 
 // Read First Bit
 state, err := reader.ReadBool()
 
-// Skip Bits/Bytes
-err := reader.SkipBits(8)
-err := reader.SkipBytes(4)
-
 // Read Bits/Bytes
-value, err := reader.ReadBytes(4)       // up to 8 bytes
 value, err := reader.ReadBits(64)       // up to 64 bits
+value, err := reader.ReadBytes(8)       // up to 8 bytes
 
 // Read String
-text, err := reader.ReadString()        // null-terminated
-text, err := reader.ReadStringLen(256)  // length-specified
+text, err := reader.ReadString()            // null-terminated
+text, err := reader.ReadStringLength(256)   // length-specified
 
 // Read Bits/Bytes into Slice
 arr, err := reader.ReadBitsToSlice(128)
 arr, err := reader.ReadBytesToSlice(64)
 
+// Skip Bits/Bytes
+err := reader.SkipBits(8)
+err := reader.SkipBytes(4)
+
 // Wrapper functions
-text := reader.TryReadString()      // string
-text := reader.TryReadStringLen(64) // string
-arr := reader.ReadBitsToSlice(128)  // []byte
-arr := reader.ReadBytesToSlice(64)  // []byte
-state := reader.TryReadBool()       // bool
-value := reader.TryReadInt1()       // uint8
-value := reader.TryReadInt8()       // uint8
-value := reader.TryReadInt16()      // uint16
-value := reader.TryReadInt32()      // uint32
-value := reader.TryReadInt64()      // uint64
-value := reader.TryReadFloat32()    // float32
-value := reader.TryReadFloat64()    // float64
-value := reader.TryReadBits(64)     // uint64
-value := reader.TryReadBytes(8)     // uint64
+state := reader.TryReadBool()           // bool
+value := reader.TryReadInt1()           // uint8
+value := reader.TryReadUInt8()          // uint8
+value := reader.TryReadSInt8()          // int8
+value := reader.TryReadUInt16()         // uint16
+value := reader.TryReadSInt16()         // int16
+value := reader.TryReadUInt32()         // uint32
+value := reader.TryReadSInt32()         // int32
+value := reader.TryReadUInt64()         // uint64
+value := reader.TryReadSInt64()         // int64
+value := reader.TryReadFloat32()        // float32
+value := reader.TryReadFloat64()        // float64
+value := reader.TryReadBits(64)         // uint64
+value := reader.TryReadBytes(8)         // uint64
+text := reader.TryReadString()          // string
+text := reader.TryReadStringLength(64)  // string
+arr := reader.TryReadBitsToSlice(1024)  // []byte
+arr := reader.TryReadBytesToSlice(128)  // []byte
+bits := reader.TryReadRemainingBits()   // uint64
 ```
 
 ## Error Handling
-ReadBits(x), ReadBytes(x), ReadBool(), ReadString(), ReadStringLen(x), ReadBitsToSlice(x), ReadBytesToSlice(x), SkipBits(x) and SkipBytes(x) functions returns an error message when they don't work as expected. It is advised to always handle errors. \
-Wrapper functions, however, only returns the value and panics if an error is encountered.
+All ReadXXX(), SkipXXX() and Fork() functions returns an error message when they don't work as expected. It is advised to always handle errors. \
+Wrapper functions, however, only returns the value and panics if an error is encountered, for the sake of ease of use.
 
 ## Bug Report / Feature Request
 Using [Github Issues](https://github.com/pektezol/BitReader/issues/new/choose), you can report a bug that you encountered and/or request a feature that you would like to be added.

--- a/bitreader_test.go
+++ b/bitreader_test.go
@@ -1,212 +1,1385 @@
+// BitReader is a simple bit reader with big/little-endian support for golang.
+// %83.2 coerage
 package bitreader
 
 import (
 	"bytes"
+	"io"
+	"math"
+	"reflect"
 	"testing"
 )
 
-// TODO: Write better unit tests
-
-// 01110001, 00001101, 00000000, 00000000, 10100010, 00011011, 00000000, 00000000, 11001100
-var TestArray = [...]byte{113, 13, 0, 0, 162, 27, 0, 0, 204}
-
-func TestTryReadFloat32(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), false)
-	expected := []float32{6.98198182157e+29, -2.10064170919e-18}
-	for i := range expected {
-		value := bitreader.TryReadFloat32()
-		if value != expected[i] {
-			t.Fatalf("TryReadFloat32 FAIL for index %d: Expected %f, Got %f", i, expected[i], value)
-		}
+func TestNewReader(t *testing.T) {
+	stream := bytes.NewReader([]byte{0x01, 0x02, 0x03})
+	type args struct {
+		stream       io.Reader
+		littleEndian bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Reader
+	}{
+		{
+			name: "ReaderLE",
+			args: args{
+				stream:       stream,
+				littleEndian: true,
+			},
+			want: &Reader{
+				stream:       stream,
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+		},
+		{
+			name: "ReaderBE",
+			args: args{
+				stream:       stream,
+				littleEndian: false,
+			},
+			want: &Reader{
+				stream:       stream,
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewReader(tt.args.stream, tt.args.littleEndian); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewReader() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestTryReadFloat64(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), false)
-	expected := []float64{3.68828741038253948851462939603e+236}
-	for i := range expected {
-		value := bitreader.TryReadFloat64()
-		if value != expected[i] {
-			t.Fatalf("TryReadFloat64 FAIL for index %d: Expected %f, Got %f", i, expected[i], value)
-		}
+func TestNewReaderFromBytes(t *testing.T) {
+	type args struct {
+		stream       []byte
+		littleEndian bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Reader
+	}{
+		{
+			name: "ReaderLE",
+			args: args{
+				stream:       []byte{0x01, 0x02, 0x03},
+				littleEndian: true,
+			},
+			want: &Reader{
+				stream:       bytes.NewReader([]byte{0x01, 0x02, 0x03}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+		},
+		{
+			name: "ReaderBE",
+			args: args{
+				stream:       []byte{0x01, 0x02, 0x03},
+				littleEndian: false,
+			},
+			want: &Reader{
+				stream:       bytes.NewReader([]byte{0x01, 0x02, 0x03}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewReaderFromBytes(tt.args.stream, tt.args.littleEndian); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewReaderFromBytes() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestTryReadInt8(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), false)
-	expected := []int{113, 13, 0}
-	for i := range expected {
-		value := bitreader.TryReadInt8()
-		if int(value) != expected[i] {
-			t.Fatalf("TryReadInt8 FAIL for index %d: Expected %d, Got %d", i, expected[i], value)
-		}
+func TestReader_Fork(t *testing.T) {
+	stream := bytes.NewReader([]byte{53})
+	tests := []struct {
+		name    string
+		reader  *Reader
+		want    *Reader
+		wantErr bool
+	}{
+		{
+			name: "Fork",
+			reader: &Reader{
+				stream:       stream,
+				index:        4,
+				currentByte:  53,
+				littleEndian: false,
+			},
+			want: &Reader{
+				index:        4,
+				currentByte:  53,
+				littleEndian: false,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.reader.Fork()
+			tt.want.stream = got.stream
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reader.Fork() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Reader.Fork() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestTryReadInt16(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), false)
-	expected := []int{28941, 0, 41499, 0}
-	for i := range expected {
-		value := bitreader.TryReadInt16()
-		if int(value) != expected[i] {
-			t.Fatalf("TryReadInt16 FAIL for index %d: Expected %d, Got %d", i, expected[i], value)
-		}
+func TestReader_TryReadBool(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   bool
+	}{
+		{
+			name: "ReadBoolTrueLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b00000001}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: true,
+		},
+		{
+			name: "ReadBoolTrueBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10000000}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: true,
+		},
+		{
+			name: "ReadBoolFalseLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b00000010}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: false,
+		},
+		{
+			name: "ReadBoolFalseBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b01000000}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadBool(); got != tt.want {
+				t.Errorf("Reader.TryReadBool() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestTryReadInt32(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), false)
-	expected := []int{1896677376, 2719678464}
-	for i := range expected {
-		value := bitreader.TryReadInt32()
-		if int(value) != expected[i] {
-			t.Fatalf("TryReadInt32 FAIL for index %d: Expected %d, Got %d", i, expected[i], value)
-		}
+func TestReader_TryReadInt1(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   uint8
+	}{
+		{
+			name: "ReadInt1TrueLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b00000001}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: 0b1,
+		},
+		{
+			name: "ReadInt1TrueBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10000000}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: 0b1,
+		},
+		{
+			name: "ReadInt1FalseLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b00000010}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: 0b0,
+		},
+		{
+			name: "ReadInt1FalseBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b01000000}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: 0b0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadInt1(); got != tt.want {
+				t.Errorf("Reader.TryReadInt1() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestTryReadInt64(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), false)
-	expected := []int{8146167303702773760}
-	for i := range expected {
-		value := bitreader.TryReadInt64()
-		if int(value) != expected[i] {
-			t.Fatalf("TryReadInt64 FAIL for index %d: Expected %d, Got %d", i, expected[i], value)
-		}
+func TestReader_TryReadUInt8(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   uint8
+	}{
+		{
+			name: "ReadUInt8LE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{202}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: 202,
+		},
+		{
+			name: "ReadUInt8BE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{202}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: 202,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadUInt8(); got != tt.want {
+				t.Errorf("Reader.TryReadUInt8() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestReadBit(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), false)
-	expected := []bool{false, true, true, true}
-	for i := range expected {
-		value, err := bitreader.ReadBool()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if value != expected[i] {
-			t.Fatalf("ReadBit FAIL for index %d: Expected %t, Got %t", i, expected[i], value)
-		}
+func TestReader_TryReadSInt8(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   int8
+	}{
+		{
+			name: "ReadSInt8LE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{202}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: -54,
+		},
+		{
+			name: "ReadSInt8BE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{202}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: -54,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadSInt8(); got != tt.want {
+				t.Errorf("Reader.TryReadSInt8() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestReadBitLE(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), true)
-	expected := []bool{true, false, false, false}
-	for i := range expected {
-		value, err := bitreader.ReadBool()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if value != expected[i] {
-			t.Fatalf("ReadBitLE FAIL for index %d: Expected %t, Got %t", i, expected[i], value)
-		}
+func TestReader_TryReadUInt16(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   uint16
+	}{
+		{
+			name: "ReadUInt16LE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: 0b0101010110101010,
+		},
+		{
+			name: "ReadUInt16BE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: 0b1010101001010101,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadUInt16(); got != tt.want {
+				t.Errorf("Reader.TryReadUInt16() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestReadBits(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), false)
-	expected := []int{3793354753, 2288779267} // 11100010000110100000000000000001, 10001000011011000000000000000011
-	expectedBool := []bool{false, false}
-	for i := range expected {
-		bool, err := bitreader.ReadBool()
-		if bool != expectedBool[i] {
-			t.Fatalf("ReadBits ReadBit FAIL for index %d: Expected %t, Got %t", i, expectedBool[i], bool)
-		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		value, err := bitreader.ReadBits(32)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if int(value) != expected[i] {
-			t.Fatalf("ReadBits FAIL for index %d: Expected %d, Got %d", i, expected[i], value)
-		}
+func TestReader_TryReadSInt16(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   int16
+	}{
+		{
+			name: "ReadSInt16LE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: 21930,
+		},
+		{
+			name: "ReadSInt16BE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: -21931,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadSInt16(); got != tt.want {
+				t.Errorf("Reader.TryReadSInt16() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestReadBitsLE(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), true)
-	expected := []int{1720, 1768} // 11010111000, 11011101000
-	for i := range expected {
-		bitreader.ReadBool()
-		value, err := bitreader.ReadBits(32)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if int(value) != expected[i] {
-			t.Fatalf("ReadBitsLE FAIL for index %d: Expected %d, Got %d", i, expected[i], value)
-		}
+func TestReader_TryReadUInt32(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   uint32
+	}{
+		{
+			name: "ReadUInt32LE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: 0b00001111111100000101010110101010,
+		},
+		{
+			name: "ReadUInt32BE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: 0b10101010010101011111000000001111,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadUInt32(); got != tt.want {
+				t.Errorf("Reader.TryReadUInt32() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestReadBytes(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), false)
-	expected := []int{3793354753, 2288779267} // 11100010000110100000000000000001, 10001000011011000000000000000011
-	expectedBool := []bool{false, false}
-	for i := range expected {
-		bool, err := bitreader.ReadBool()
-		if bool != expectedBool[i] {
-			t.Fatalf("ReadBytes ReadBit FAIL for index %d: Expected %t, Got %t", i, expectedBool[i], bool)
-		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		value, err := bitreader.ReadBytes(4)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if int(value) != expected[i] {
-			t.Fatalf("ReadBytes FAIL for index %d: Expected %d, Got %d", i, expected[i], value)
-		}
+func TestReader_TryReadSInt32(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   int32
+	}{
+		{
+			name: "ReadSInt32LE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: 267408810,
+		},
+		{
+			name: "ReadSInt32BE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: -1437208561,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadSInt32(); got != tt.want {
+				t.Errorf("Reader.TryReadSInt32() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestReadBytesLE(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), true)
-	expected := []int{1720, 1768} // 11010111000, 11011101000
-	for i := range expected {
-		bitreader.ReadBool()
-		value, err := bitreader.ReadBytes(4)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if int(value) != expected[i] {
-			t.Fatalf("ReadBytesLE FAIL for index %d: Expected %d, Got %d", i, expected[i], value)
-		}
+func TestReader_TryReadUInt64(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   uint64
+	}{
+		{
+			name: "ReadUInt64LE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111, 0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: 0b0000111111110000010101011010101000001111111100000101010110101010,
+		},
+		{
+			name: "ReadUInt64BE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111, 0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: 0b1010101001010101111100000000111110101010010101011111000000001111,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadUInt64(); got != tt.want {
+				t.Errorf("Reader.TryReadUInt64() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestSkipBits(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), false)
-	expected := []bool{true, true, false, true} //00001101
-	err := bitreader.SkipBits(12)
-	if err != nil {
-		t.Fatal(err)
+func TestReader_TryReadSInt64(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   int64
+	}{
+		{
+			name: "ReadSInt64LE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111, 0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: 1148512093879686570,
+		},
+		{
+			name: "ReadSInt64BE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111, 0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: -6172763764168462321,
+		},
 	}
-	for i := range expected {
-		value, err := bitreader.ReadBool()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if value != expected[i] {
-			t.Fatalf("SkipBits ReadBit FAIL for index %d: Expected %t, Got %t", i, expected[i], value)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadSInt64(); got != tt.want {
+				t.Errorf("Reader.TryReadSInt64() = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestSkipBitsLE(t *testing.T) {
-	bitreader := Reader(bytes.NewReader(TestArray[:]), true)
-	expected := []bool{false, false, false, false} //10110000
-	bitreader.SkipBits(12)
-	for i := range expected {
-		value, err := bitreader.ReadBool()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if value != expected[i] {
-			t.Fatalf("SkipBitsLE ReadBit FAIL for index %d: Expected %t, Got %t", i, expected[i], value)
-		}
+func TestReader_TryReadFloat32(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   float32
+	}{
+		{
+			name: "ReadFloat32LE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: math.Float32frombits(0b00001111111100000101010110101010),
+		},
+		{
+			name: "ReadFloat32BE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: math.Float32frombits(0b10101010010101011111000000001111),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadFloat32(); got != tt.want {
+				t.Errorf("Reader.TryReadFloat32() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_TryReadFloat64(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   float64
+	}{
+		{
+			name: "ReadFloat64LE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111, 0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: math.Float64frombits(0b0000111111110000010101011010101000001111111100000101010110101010),
+		},
+		{
+			name: "ReadFloat64BE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10101010, 0b01010101, 0b11110000, 0b00001111, 0b10101010, 0b01010101, 0b11110000, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: math.Float64frombits(0b1010101001010101111100000000111110101010010101011111000000001111),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadFloat64(); got != tt.want {
+				t.Errorf("Reader.TryReadFloat64() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_TryReadBits(t *testing.T) {
+	type args struct {
+		bits int
+	}
+	tests := []struct {
+		name   string
+		reader *Reader
+		args   args
+		want   uint64
+	}{
+		{
+			name: "ReadBitsLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110000, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				bits: 12,
+			},
+			want: 0b010111110000,
+		},
+		{
+			name: "ReadBitsBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110000, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				bits: 12,
+			},
+			want: 0b111100000101,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadBits(tt.args.bits); got != tt.want {
+				t.Errorf("Reader.TryReadBits() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_TryReadBytes(t *testing.T) {
+	type args struct {
+		bytes int
+	}
+	tests := []struct {
+		name   string
+		reader *Reader
+		args   args
+		want   uint64
+	}{
+		{
+			name: "ReadBytesLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110000, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				bytes: 2,
+			},
+			want: 0b0101010111110000,
+		},
+		{
+			name: "ReadBytesBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110000, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				bytes: 2,
+			},
+			want: 0b1111000001010101,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadBytes(tt.args.bytes); got != tt.want {
+				t.Errorf("Reader.TryReadBytes() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_TryReadString(t *testing.T) {
+	tests := []struct {
+		name   string
+		reader *Reader
+		want   string
+	}{
+		{
+			name: "ReadStringLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{'H', 'e', 'l', 'l', 'o', 0, '!'}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: "Hello",
+		},
+		{
+			name: "ReadStringBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{'W', 'o', 'r', 'l', 'd', 0, '!'}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: "World",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadString(); got != tt.want {
+				t.Errorf("Reader.TryReadString() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_TryReadStringLength(t *testing.T) {
+	type args struct {
+		length int
+	}
+	tests := []struct {
+		name   string
+		reader *Reader
+		args   args
+		want   string
+	}{
+		{
+			name: "ReadStringLengthLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{'H', 'e', 'l', 'l', 'o', 0, '!'}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				length: 4,
+			},
+			want: "Hell",
+		},
+		{
+			name: "ReadStringLengthBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{'W', 'o', 'r', 'l', 'd', '!', '?'}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				length: 6,
+			},
+			want: "World!",
+		},
+		{
+			name: "ReadStringLengthNullHitBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{'W', 'o', 'r', 'l', 'd', 0, '!', '?'}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				length: 7,
+			},
+			want: "World",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadStringLength(tt.args.length); got != tt.want {
+				t.Errorf("Reader.TryReadStringLength() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_TryReadBitsToSlice(t *testing.T) {
+	type args struct {
+		bits int
+	}
+	tests := []struct {
+		name   string
+		reader *Reader
+		args   args
+		want   []byte
+	}{
+		{
+			name: "ReadBitsToSliceBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				bits: 12,
+			},
+			want: []byte{0b11110010, 0b0},
+		},
+		{
+			name: "ReadBitsToSliceLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				bits: 12,
+			},
+			want: []byte{0b11110010, 0b00001111},
+		},
+		{
+			name: "ReadBitsToSliceBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				bits: 16,
+			},
+			want: []byte{0b11110010, 0b00001111},
+		},
+		{
+			name: "ReadBitsToSliceLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				bits: 16,
+			},
+			want: []byte{0b11110010, 0b00001111},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadBitsToSlice(tt.args.bits); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Reader.TryReadBitsToSlice() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_TryReadBytesToSlice(t *testing.T) {
+	type args struct {
+		bytes int
+	}
+	tests := []struct {
+		name   string
+		reader *Reader
+		args   args
+		want   []byte
+	}{
+		{
+			name: "ReadBytesToSliceBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				bytes: 2,
+			},
+			want: []byte{0b11110010, 0b00001111},
+		},
+		{
+			name: "ReadBytesToSliceLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				bytes: 2,
+			},
+			want: []byte{0b11110010, 0b00001111},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reader.TryReadBytesToSlice(tt.args.bytes); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Reader.TryReadBytesToSlice() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_TryReadRemainingBits(t *testing.T) {
+	tests := []struct {
+		name    string
+		reader  *Reader
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name: "ReadRemainingBits",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0x11, 0x22}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want:    16,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.reader.TryReadRemainingBits()
+			if got != tt.want {
+				t.Errorf("Reader.TryReadRemainingBits() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_ReadBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		reader  *Reader
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "ReadBoolTrueLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b00000001}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: true,
+		},
+		{
+			name: "ReadBoolTrueBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b10000000}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: true,
+		},
+		{
+			name: "ReadBoolFalseLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b00000010}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: false,
+		},
+		{
+			name: "ReadBoolFalseBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b01000000}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.reader.ReadBool()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reader.ReadBool() error = %+v, wantErr %+v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Reader.ReadBool() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_ReadBits(t *testing.T) {
+	type args struct {
+		bits int
+	}
+	tests := []struct {
+		name    string
+		reader  *Reader
+		args    args
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name: "ReadBitsLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110000, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				bits: 12,
+			},
+			want: 0b010111110000,
+		},
+		{
+			name: "ReadBitsBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110000, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				bits: 12,
+			},
+			want: 0b111100000101,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.reader.ReadBits(tt.args.bits)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reader.ReadBits() error = %+v, wantErr %+v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Reader.ReadBits() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_ReadBytes(t *testing.T) {
+	type args struct {
+		bytes int
+	}
+	tests := []struct {
+		name    string
+		reader  *Reader
+		args    args
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name: "ReadBytesLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110000, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				bytes: 2,
+			},
+			want: 0b0101010111110000,
+		},
+		{
+			name: "ReadBytesBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110000, 0b01010101}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				bytes: 2,
+			},
+			want: 0b1111000001010101,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.reader.ReadBytes(tt.args.bytes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reader.ReadBytes() error = %+v, wantErr %+v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Reader.ReadBytes() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_ReadString(t *testing.T) {
+	tests := []struct {
+		name    string
+		reader  *Reader
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "ReadStringLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{'H', 'e', 'l', 'l', 'o', 0, '!'}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			want: "Hello",
+		},
+		{
+			name: "ReadStringBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{'W', 'o', 'r', 'l', 'd', 0, '!'}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want: "World",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.reader.ReadString()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reader.ReadString() error = %+v, wantErr %+v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Reader.ReadString() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_ReadStringLength(t *testing.T) {
+	type args struct {
+		length int
+	}
+	tests := []struct {
+		name    string
+		reader  *Reader
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "ReadStringLengthLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{'H', 'e', 'l', 'l', 'o', 0, '!'}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				length: 4,
+			},
+			want: "Hell",
+		},
+		{
+			name: "ReadStringLengthBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{'W', 'o', 'r', 'l', 'd', '!', '?'}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				length: 6,
+			},
+			want: "World!",
+		},
+		{
+			name: "ReadStringLengthNullHitBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{'W', 'o', 'r', 'l', 'd', 0, '!', '?'}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				length: 7,
+			},
+			want: "World",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.reader.ReadStringLength(tt.args.length)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reader.ReadStringLength() error = %+v, wantErr %+v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Reader.ReadStringLength() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_ReadBitsToSlice(t *testing.T) {
+	type args struct {
+		bits int
+	}
+	tests := []struct {
+		name    string
+		reader  *Reader
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "ReadBitsToSliceBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				bits: 12,
+			},
+			want: []byte{0b11110010, 0b0},
+		},
+		{
+			name: "ReadBitsToSliceLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				bits: 12,
+			},
+			want: []byte{0b11110010, 0b00001111},
+		},
+		{
+			name: "ReadBitsToSliceBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				bits: 16,
+			},
+			want: []byte{0b11110010, 0b00001111},
+		},
+		{
+			name: "ReadBitsToSliceLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				bits: 16,
+			},
+			want: []byte{0b11110010, 0b00001111},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.reader.ReadBitsToSlice(tt.args.bits)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reader.ReadBitsToSlice() error = %+v, wantErr %+v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Reader.ReadBitsToSlice() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_ReadBytesToSlice(t *testing.T) {
+	type args struct {
+		bytes int
+	}
+	tests := []struct {
+		name    string
+		reader  *Reader
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "ReadBytesToSliceBE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			args: args{
+				bytes: 2,
+			},
+			want: []byte{0b11110010, 0b00001111},
+		},
+		{
+			name: "ReadBytesToSliceLE",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0b11110010, 0b00001111}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: true,
+			},
+			args: args{
+				bytes: 2,
+			},
+			want: []byte{0b11110010, 0b00001111},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.reader.ReadBytesToSlice(tt.args.bytes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reader.ReadBytesToSlice() error = %+v, wantErr %+v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Reader.ReadBytesToSlice() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReader_ReadRemainingBits(t *testing.T) {
+	tests := []struct {
+		name    string
+		reader  *Reader
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name: "ReadRemainingBits",
+			reader: &Reader{
+				stream:       bytes.NewReader([]byte{0x11, 0x22}),
+				index:        0,
+				currentByte:  0,
+				littleEndian: false,
+			},
+			want:    16,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.reader.ReadRemainingBits()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reader.ReadRemainingBits() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Reader.ReadRemainingBits() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Changed the TryRead functions to specify signed and unsigned versions. (Breaks major release, but no one cares lol)
- Changed constructor function name to NewReader, also added NewReaderFromBytes to construct with a byte slice.
- Changed ReadStringLen to ReadStringLength, its 2023, don't be concise(?)
- Changed the Reader type name from ReaderType to Reader.
- Changed Reader type's field names to be less concise.
- Changed TryReadString and TryReadStringLength to panic when there's an error.
- Added new function: Fork, which copies the reader with all of its properties.
- Added new function: ReadRemainingBits, which returns the total number of bits left in the stream, without messing with it. (Done via Forking)
- Fixed bug where SkipBits didn't work as intended for bits < 8. Previously, it prematurely returned an EOF.
- Reworked unit tests for new and changed functions. Currently has an %83.2 coverage.